### PR TITLE
Make Enabling and Disabling SelfHealingUrls via Middleware More Flexible

### DIFF
--- a/src/HasSelfHealingUrls.php
+++ b/src/HasSelfHealingUrls.php
@@ -183,18 +183,18 @@ trait HasSelfHealingUrls
     {
         $activeMiddleware = request()->route()?->middleware();
 
-        if ($activeMiddleware) {
-
-            if (in_array(EnableSelfHealingUrls::class, $activeMiddleware)) {
-                $this->selfHealingUrlActive = true;
-            }
-            if (in_array(DisableSelfHealingUrls::class, $activeMiddleware)) {
-                $this->selfHealingUrlActive = false;
-            }
-        } elseif (request()->attributes->get('disable_self_healing_urls')) {
-            $this->selfHealingUrlActive = request()->attributes->get('disable_self_healing_urls');
-            return request()->attributes->get('disable_self_healing_urls');
+        if ($activeMiddleware && in_array(EnableSelfHealingUrls::class, $activeMiddleware)) {
+            return $this->selfHealingUrlActive = true;
         }
+
+        if ($activeMiddleware && in_array(DisableSelfHealingUrls::class, $activeMiddleware)) {
+            return $this->selfHealingUrlActive = false;
+        }
+
+        if (request()->attributes->has('disable_self_healing_urls')) {
+            return $this->selfHealingUrlActive = request()->attributes->get('disable_self_healing_urls');
+        }
+        
         return $this->selfHealingUrlActive;
     }
 

--- a/src/Middleware/EnableSelfHealingUrls.php
+++ b/src/Middleware/EnableSelfHealingUrls.php
@@ -5,11 +5,11 @@ namespace Motomedialab\LaravelSelfHealingUrls\Middleware;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class DisableSelfHealingUrls
+class EnableSelfHealingUrls
 {
     public function handle(Request $request, \Closure $next): Response
     {
-        $request->attributes->set('disable_self_healing_urls', true);
+        $request->attributes->set('disable_self_healing_urls', false);
         return $next($request);
     }
 }


### PR DESCRIPTION
If middleware is active on route, then we are inverting the default action. Since we may want the default action not to use the selfhealingurls, we can set the property $selfHealingUrlActive to false. Also checking for the presence of the middleware, removes the limitation of requiring the middleware to be called before the web middleware.